### PR TITLE
Added missing files for rabbitmq spec

### DIFF
--- a/rabbitmq/Rakefile
+++ b/rabbitmq/Rakefile
@@ -1,0 +1,34 @@
+require 'rake'
+require 'rspec/core/rake_task'
+require 'yaml'
+
+task :spec    => 'spec:all'
+task :default => :spec
+
+if File.file?('properties.yaml')
+  properties = YAML.load_file('properties.yaml')
+else
+  properties = nil
+end
+
+namespace :spec do
+  targets = []
+  Dir.glob('./spec/*').each do |dir|
+    next unless File.directory?(dir)
+    targets << File.basename(dir)
+  end
+
+  task :all     => targets
+  task :default => :all
+
+  targets.each do |target|
+    desc "Run serverspec tests to #{target}"
+    RSpec::Core::RakeTask.new(target.to_sym) do |t|
+      ENV['TARGET_HOST'] = target
+      if properties
+        set_property properties
+      end
+      t.pattern = "spec/#{target}/*_spec.rb"
+    end
+  end
+end

--- a/rabbitmq/spec/spec_helper.rb
+++ b/rabbitmq/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'serverspec'
+
+set :backend, :exec
+


### PR DESCRIPTION
rabbitmq subtree was missing Rakefile and spec_helper. I started the spec and seen that it checks for port 5672 which is the standard port for rabbitmq (and is in fact the one used for tcp6), but puppet set it to 25672, so the spec fails. Which one is correct ?